### PR TITLE
fix bug in looping over too many edges in graph construction

### DIFF
--- a/include/graph/forward_star_factory.hpp
+++ b/include/graph/forward_star_factory.hpp
@@ -55,7 +55,7 @@ ForwardStarGraph ForwardStarGraphFactory::produce_directed_from_edges(
   auto edge = edges.begin();
   for (std::uint64_t node = 0; node < number_of_nodes; ++node) {
     // add all edges to the graph
-    while (extractor.source(*edge) == node) {
+    while (edge != edges.end() && extractor.source(*edge) == node) {
       auto target = extractor.target(*edge);
       if (target >= number_of_nodes)
         throw std::out_of_range{


### PR DESCRIPTION
There is a bug in forward star graph construction that loops over more edges than are present, if the last node does not have any edges and has random behavior in all other cases.