### PR TITLE
Weight/Data decorators for graphs

### DIFF
--- a/include/graph/decorator.hpp
+++ b/include/graph/decorator.hpp
@@ -1,0 +1,188 @@
+#ifndef PROJECT_X_GRAPH_DECORATOR_HPP_
+#define PROJECT_X_GRAPH_DECORATOR_HPP_
+
+#include "graph/id.hpp"
+#include "io/file.hpp"
+#include "io/serialisable.hpp"
+#include "io/wrappers.hpp"
+
+#include <string>
+#include <vector>
+
+// Decorators are a way of adding user data to a forward star graph
+// representation that is supposed to be used within navigation / returned from
+// the API. A cost type in general is required to allow shortest path
+// computation. We allow cost to be templated, so that we can induce different
+// structs and can return combinations of weight/distance/time
+namespace project_x {
+namespace graph {
+
+// forward declaration to put this into the graph, not the graph::edge namespace
+class DecoratorFactory;
+
+namespace edge {
+template <typename cost_type_t, class graph_type>
+class CostDecorator : public graph_type {
+public:
+  using cost_type = cost_type_t;
+  template <class base_graph> CostDecorator(base_graph &&graph);
+  CostDecorator() = default;
+
+  cost_type &cost(EdgeID const);
+  cost_type const &cost(EdgeID const) const;
+
+  void serialise(io::File &) const;
+  void deserialise(io::File &);
+
+  friend DecoratorFactory;
+
+private:
+  std::vector<cost_type> decoration;
+};
+
+// The data decorator allows to store whatever kind of additional data we want
+// to connect with the graphs edges. Data on edges might be connected to street
+// names, road types or similar but could also represent the color of a public
+// transit line or other types of data.
+template <typename data_type_t, class graph_type>
+class DataDecorator : public graph_type {
+public:
+  using data_type = data_type_t;
+
+  template <class base_graph> DataDecorator(base_graph &&graph);
+  DataDecorator() = default;
+
+  data_type &data(EdgeID const);
+  data_type const &data(EdgeID const) const;
+
+  void serialise(io::File &) const;
+  void deserialise(io::File &);
+
+  friend DecoratorFactory;
+
+private:
+  std::vector<data_type> decoration;
+};
+
+// Byte decorators are used to store arbitrary data on edges that will be
+// returned via the API. If you want to encode data that will be part of any
+// path in the graph, put it in here. All the contents will be added to the
+// resulting path.
+template <class graph_type> class ByteDecorator : public graph_type {
+public:
+  using byte_string = std::string;
+  using wrapped_byte_string = io::SerialisableContainer<std::string>;
+
+  template <class base_graph> ByteDecorator(base_graph &&graph);
+  ByteDecorator() = default;
+
+  byte_string &bytes(EdgeID const);
+  byte_string const &bytes(EdgeID const) const;
+
+  void serialise(io::File &) const;
+  void deserialise(io::File &);
+
+  friend DecoratorFactory;
+
+private:
+  std::vector<wrapped_byte_string> decoration;
+};
+
+//////////////////////////////////////////////////////////////////
+// Implementations
+//////////////////////////////////////////////////////////////////
+
+template <typename cost_type_t, class graph_type>
+template <class base_graph>
+CostDecorator<cost_type_t, graph_type>::CostDecorator(base_graph &&graph)
+    : graph_type(std::move(graph)) {}
+
+template <typename cost_type_t, class graph_type>
+cost_type_t &CostDecorator<cost_type_t, graph_type>::cost(EdgeID const eid) {
+  return decoration[eid];
+}
+
+template <typename cost_type_t, class graph_type>
+cost_type_t const &
+CostDecorator<cost_type_t, graph_type>::cost(EdgeID const eid) const {
+  return decoration[eid];
+}
+
+template <typename cost_type_t, class graph_type>
+void CostDecorator<cost_type_t, graph_type>::serialise(io::File &file) const {
+  graph_type::serialise(file);
+  file.write_container(decoration);
+}
+
+template <typename cost_type_t, class graph_type>
+void CostDecorator<cost_type_t, graph_type>::deserialise(io::File &file) {
+  graph_type::deserialise(file);
+  file.read_container(decoration);
+}
+
+//////////////////////////////////////////////////////////////////
+
+template <typename data_type_t, class graph_type>
+template <class base_graph>
+DataDecorator<data_type_t, graph_type>::DataDecorator(base_graph &&graph)
+    : graph_type(std::move(graph)) {}
+
+template <typename data_type_t, class graph_type>
+data_type_t &DataDecorator<data_type_t, graph_type>::data(EdgeID const eid) {
+  return decoration[eid];
+}
+
+template <typename data_type_t, class graph_type>
+data_type_t const &
+DataDecorator<data_type_t, graph_type>::data(EdgeID const eid) const {
+  return decoration[eid];
+}
+
+template <typename data_type_t, class graph_type>
+void DataDecorator<data_type_t, graph_type>::serialise(io::File &file) const {
+  graph_type::serialise(file);
+  file.write_container(decoration);
+}
+
+template <typename data_type_t, class graph_type>
+void DataDecorator<data_type_t, graph_type>::deserialise(io::File &file) {
+  graph_type::deserialise(file);
+  file.read_container(decoration);
+}
+
+//////////////////////////////////////////////////////////////////
+
+template <class graph_type>
+template <class base_graph>
+ByteDecorator<graph_type>::ByteDecorator(base_graph &&graph)
+    : graph_type(std::move(graph)) {}
+
+template <class graph_type>
+typename ByteDecorator<graph_type>::byte_string &
+ByteDecorator<graph_type>::bytes(EdgeID const eid) {
+  return decoration[eid].wrapped_object;
+}
+
+template <class graph_type>
+typename ByteDecorator<graph_type>::byte_string const &
+ByteDecorator<graph_type>::bytes(EdgeID const eid) const {
+  return decoration[eid].wrapped_object;
+}
+
+template <class graph_type>
+void ByteDecorator<graph_type>::serialise(io::File &file) const {
+  graph_type::serialise(file);
+  file.write_container(decoration);
+}
+
+template <class graph_type>
+void ByteDecorator<graph_type>::deserialise(io::File &file) {
+  graph_type::deserialise(file);
+  file.read_container(decoration);
+}
+
+} // namespace edge
+} // namespace graph
+} // namespace project_x
+
+#endif // PROJECT_X_GRAPH_DECORATOR_HPP_

--- a/include/graph/decorator_factory.hpp
+++ b/include/graph/decorator_factory.hpp
@@ -1,0 +1,30 @@
+#ifndef PROJECT_X_GRAPH_DECORATOR_FACTORY_HPP_
+#define PROJECT_X_GRAPH_DECORATOR_FACTORY_HPP_
+
+#include "decorator.hpp"
+#include "forward_star.hpp"
+
+namespace project_x {
+namespace graph {
+class DecoratorFactory {
+public:
+  template <typename decorated_graph_type, typename edge_container,
+            typename converter>
+  void decorate(decorated_graph_type &graph, edge_container &edges,
+                converter cvt) const;
+};
+
+template <typename decorated_graph_type, typename edge_container,
+          typename converter>
+void DecoratorFactory::decorate(decorated_graph_type &graph,
+                                edge_container &edges, converter cvt) const {
+  graph.decoration.reserve(edges.size());
+  for (auto const &edge : edges) {
+    graph.decoration.push_back(cvt(edge));
+  }
+}
+
+} // namespace graph
+} // namespace project_x
+
+#endif // PROJECT_X_GRAPH_DECORATOR_FACTORY_HPP_

--- a/include/graph/forward_star.hpp
+++ b/include/graph/forward_star.hpp
@@ -42,6 +42,7 @@ public:
 
   // the number of nodes in the graph. All nodes are labeled from 0 to n-1
   std::size_t number_of_nodes() const;
+  std::size_t number_of_edges() const;
 
   // access to nodes by id, begin/end or range
   node_iterator node_begin();
@@ -92,13 +93,10 @@ public:
   EdgeID edge_id(edge_iterator const) const;
 
   // storing / restoring
-  void serialise(io::File &file) const final;
-  void deserialise(io::File &file) final;
+  void serialise(io::File &file) const;
+  void deserialise(io::File &file);
 
 private:
-  // cannot construct without an appropriate factory
-  ForwardStar();
-
   offset_storage node_offsets;
   storage_type edge_storage;
 

--- a/include/graph/routing.hpp
+++ b/include/graph/routing.hpp
@@ -1,0 +1,36 @@
+#ifndef PROJECT_X_GRAPH_ROUTING_HPP_
+#define PROJECT_X_GRAPH_ROUTING_HPP_
+
+#include "decorator.hpp"
+#include "forward_star.hpp"
+
+#include <cstdint>
+
+namespace project_x {
+namespace graph {
+
+struct WeightTimeDistance {
+  std::uint32_t weight;
+  std::uint32_t time;
+  std::uint32_t distance;
+
+  bool operator<(WeightTimeDistance const &other) const;
+  bool operator<=(WeightTimeDistance const &other) const;
+  bool operator>(WeightTimeDistance const &other) const;
+  bool operator>=(WeightTimeDistance const &other) const;
+  bool operator==(WeightTimeDistance const &other) const;
+  bool operator!=(WeightTimeDistance const &other) const;
+
+  WeightTimeDistance operator+(WeightTimeDistance const &other) const;
+  WeightTimeDistance operator+=(WeightTimeDistance const &other);
+  WeightTimeDistance operator-(WeightTimeDistance const &other) const;
+  WeightTimeDistance operator-=(WeightTimeDistance const &other);
+};
+
+// The routing graph
+using RoutingGraph = edge::CostDecorator<WeightTimeDistance, ForwardStar>;
+
+} // namespace graph
+} // namespace project_x
+
+#endif // PROJECT_X_GRAPH_ROUTING_HPP_

--- a/include/io/serialisable.hpp
+++ b/include/io/serialisable.hpp
@@ -1,10 +1,11 @@
 #ifndef PROJECT_X_IO_SERIALISABLE_HPP_
 #define PROJECT_X_IO_SERIALISABLE_HPP_
 
-#include "io/file.hpp"
-
 namespace project_x {
 namespace io {
+
+class File;
+
 // Interface for all serialisable objects
 class Serialisable {
   virtual void serialise(File &file) const = 0;

--- a/include/io/wrappers.hpp
+++ b/include/io/wrappers.hpp
@@ -1,0 +1,48 @@
+#ifndef PROJECT_X_IO_WRAPPERS_HPP_
+#define PROJECT_X_IO_WRAPPERS_HPP_
+
+#include "io/file.hpp"
+#include "io/serialisable.hpp"
+
+namespace project_x {
+namespace io {
+
+template <typename base_type>
+struct SerialisableContainer : public io::Serialisable {
+  SerialisableContainer() : wrapped_object(){};
+  SerialisableContainer(base_type wrapped_object_)
+      : wrapped_object(wrapped_object_){};
+
+  void serialise(File &) const;
+  void deserialise(File &);
+
+  base_type &operator*();
+  base_type const &operator*() const;
+
+  base_type wrapped_object;
+};
+
+template <typename base_type>
+void SerialisableContainer<base_type>::serialise(File &file) const {
+  file.write_container(wrapped_object);
+}
+
+template <typename base_type>
+void SerialisableContainer<base_type>::deserialise(File &file) {
+  file.read_container(wrapped_object);
+}
+
+template <typename base_type>
+base_type &SerialisableContainer<base_type>::operator*() {
+  return wrapped_object;
+}
+
+template <typename base_type>
+base_type const &SerialisableContainer<base_type>::operator*() const {
+  return wrapped_object;
+}
+
+} // namespace io
+} // namespace project_x
+
+#endif // PROJECT_X_IO_WRAPPERS_HPP_

--- a/scripts/python/profiles/car.py
+++ b/scripts/python/profiles/car.py
@@ -28,4 +28,4 @@ class OSMCar:
         if osm_way.tags['highway'] not in self.highway_speeds:
             raise InvalidArgument
 
-        return highways[osm_way.tags['highway']]
+        return highway_speeds[osm_way.tags['highway']]

--- a/src/graph/CMakeLists.txt
+++ b/src/graph/CMakeLists.txt
@@ -1,6 +1,7 @@
 set (graph_SOURCES
   forward_star.cpp
-  forward_star_factory.cpp)
+  forward_star_factory.cpp
+  routing.cpp)
 
 add_library(Xgraph STATIC
   ${graph_SOURCES})

--- a/src/graph/forward_star.cpp
+++ b/src/graph/forward_star.cpp
@@ -8,14 +8,14 @@ namespace project_x {
 namespace graph {
 
 // construction
-ForwardStar::ForwardStar() {}
-
 std::size_t ForwardStar::number_of_nodes() const {
   // a graph should never be empty. The factory always needs to add at least a
   // sentinel
   assert(!node_offsets.empty());
   return node_offsets.size() - 1;
 }
+
+std::size_t ForwardStar::number_of_edges() const { return edge_storage.size(); }
 
 // ranges / begin / end
 ForwardStar::node_iterator ForwardStar::node_begin() {
@@ -144,24 +144,18 @@ void ForwardStar::serialise(io::File &file) const {
   logger.message(log::Level::DEBUG,
                  "Serialise: writing " + std::to_string(count_offsets - 1) +
                      " nodes and " + std::to_string(count_targets) + " edges.");
-  file.write_pod(count_offsets);
-  file.write_pod(count_targets);
-  file.write_pod(node_offsets);
-  file.write_pod(edge_storage);
+  file.write_container(node_offsets);
+  file.write_container(edge_storage);
 }
 
 void ForwardStar::deserialise(io::File &file) {
+  file.read_container(node_offsets);
+  file.read_container(edge_storage);
   log::Logger logger;
-  std::uint64_t count_offsets = 0, count_targets = 0;
-  file.read_pod(count_offsets);
-  file.read_pod(count_targets);
   logger.message(log::Level::DEBUG,
-                 "Deserialise: got " + std::to_string(count_offsets - 1) +
-                     " nodes and " + std::to_string(count_targets) + " edges.");
-  node_offsets.resize(count_offsets);
-  edge_storage.resize(count_targets);
-  file.read_pod(node_offsets);
-  file.read_pod(edge_storage);
+                 "Deserialise: got " + std::to_string(node_offsets.size() - 1) +
+                     " nodes and " + std::to_string(edge_storage.size()) +
+                     " edges.");
 }
 
 } // namespace graph

--- a/src/graph/routing.cpp
+++ b/src/graph/routing.cpp
@@ -1,0 +1,69 @@
+#include "graph/routing.hpp"
+
+#include <tuple>
+
+namespace project_x {
+namespace graph {
+
+bool WeightTimeDistance::operator<(WeightTimeDistance const &other) const {
+  return std::tie(weight, time, distance) <
+         std::tie(other.weight, other.time, other.distance);
+}
+
+bool WeightTimeDistance::operator<=(WeightTimeDistance const &other) const {
+  return std::tie(weight, time, distance) <=
+         std::tie(other.weight, other.time, other.distance);
+}
+
+bool WeightTimeDistance::operator>(WeightTimeDistance const &other) const {
+  return std::tie(weight, time, distance) >
+         std::tie(other.weight, other.time, other.distance);
+}
+
+bool WeightTimeDistance::operator>=(WeightTimeDistance const &other) const {
+  return std::tie(weight, time, distance) >=
+         std::tie(other.weight, other.time, other.distance);
+}
+
+bool WeightTimeDistance::operator==(WeightTimeDistance const &other) const {
+  return std::tie(weight, time, distance) ==
+         std::tie(other.weight, other.time, other.distance);
+}
+
+bool WeightTimeDistance::operator!=(WeightTimeDistance const &other) const {
+  return std::tie(weight, time, distance) !=
+         std::tie(other.weight, other.time, other.distance);
+}
+
+WeightTimeDistance WeightTimeDistance::
+operator+=(WeightTimeDistance const &other) {
+  weight += other.weight;
+  time += other.time;
+  distance += other.distance;
+  return *this;
+}
+
+WeightTimeDistance WeightTimeDistance::
+operator+(WeightTimeDistance const &other) const {
+  auto copy = *this;
+  copy += other;
+  return copy;
+}
+
+WeightTimeDistance WeightTimeDistance::
+operator-=(WeightTimeDistance const &other) {
+  weight -= other.weight;
+  time -= other.time;
+  distance -= other.distance;
+  return *this;
+}
+
+WeightTimeDistance WeightTimeDistance::
+operator-(WeightTimeDistance const &other) const {
+  auto copy = *this;
+  copy -= other;
+  return copy;
+}
+
+} // namespace graph
+} // namespace project_x

--- a/test/graph/CMakeLists.txt
+++ b/test/graph/CMakeLists.txt
@@ -9,3 +9,5 @@ set(testINCLUDES
   )
 
 add_unit_test(forward_star forward_star.cpp "${testLIBS}" "${testINCLUDES}")
+add_unit_test(routing routing.cpp "${testLIBS}" "${testINCLUDES}")
+add_unit_test(decorator decorator.cpp "${testLIBS}" "${testINCLUDES}")

--- a/test/graph/decorator.cpp
+++ b/test/graph/decorator.cpp
@@ -1,0 +1,83 @@
+#include "graph/decorator.hpp"
+#include "graph/decorator_factory.hpp"
+#include "graph/forward_star.hpp"
+#include "graph/forward_star_factory.hpp"
+#include "graph/id.hpp"
+#include "io/file.hpp"
+#include "io/wrappers.hpp"
+#include "log/logger.hpp"
+
+#include <algorithm>
+#include <exception>
+#include <string>
+#include <vector>
+
+// make sure we get a new main function here
+#define BOOST_TEST_MODULE Decorator
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+using namespace project_x;
+
+struct Data {
+  int data;
+};
+
+struct Cost {
+  int weight;
+};
+
+struct Edge {
+  NodeID source, target;
+  Data data;
+  Cost cost;
+};
+
+// Fully Annotated Graph
+using CostGraph = graph::edge::CostDecorator<Cost, graph::ForwardStar>;
+using DataCostGraph = graph::edge::DataDecorator<Data, CostGraph>;
+using AnnotatedGraph = graph::edge::ByteDecorator<DataCostGraph>;
+
+AnnotatedGraph make_graph() {
+  std::vector<Edge> edges{{0, 1, {1}, {2}},  {2, 1, {3}, {4}},
+                          {1, 2, {5}, {6}},  {1, 0, {7}, {8}},
+                          {3, 4, {9}, {10}}, {3, 5, {11}, {12}}};
+  AnnotatedGraph graph(
+      graph::ForwardStarFactory::produce_directed_from_edges(7, edges));
+
+  graph::DecoratorFactory decorator_factory;
+  decorator_factory.decorate<CostGraph>(
+      graph, edges, [](auto const &edge) { return edge.cost; });
+  decorator_factory.decorate<DataCostGraph>(
+      graph, edges, [](auto const &edge) { return edge.data; });
+  decorator_factory.decorate<AnnotatedGraph>(graph, edges, [](auto const &) {
+    return io::SerialisableContainer<std::string>("Hello World");
+  });
+
+  return graph;
+}
+
+// test a construction of an undirected graph from a set of edges
+BOOST_AUTO_TEST_CASE(check_annotations) {
+  // create the basic graph to check the annotations on
+  auto const graph = make_graph();
+
+  io::File out_file("decorated_graph.dgr",
+                    io::mode::mWRITE | io::mode::mBINARY |
+                        io::mode::mVERSIONED);
+  graph.serialise(out_file);
+  out_file.close();
+
+  AnnotatedGraph read_graph;
+  io::File in_file("decorated_graph.dgr",
+                   io::mode::mREAD | io::mode::mBINARY | io::mode::mVERSIONED);
+  read_graph.deserialise(in_file);
+
+  for (EdgeID eid = 0; eid < graph.number_of_edges(); ++eid) {
+    BOOST_CHECK_EQUAL(graph.cost(eid).weight, read_graph.cost(eid).weight);
+    BOOST_CHECK_EQUAL(graph.data(eid).data, read_graph.data(eid).data);
+    BOOST_CHECK_EQUAL(graph.bytes(eid), read_graph.bytes(eid));
+  }
+
+  // query and verify all annotations for the graph
+}

--- a/test/graph/forward_star.cpp
+++ b/test/graph/forward_star.cpp
@@ -23,6 +23,7 @@ namespace details {
 template <typename graph_type>
 void run_test(graph_type &graph, std::vector<Edge> const &edges) {
   BOOST_CHECK_EQUAL(graph.number_of_nodes(), 7);
+  BOOST_CHECK_EQUAL(graph.number_of_edges(), 6);
   {
     auto edge_itr = graph.edges_begin();
     auto edge_end = graph.edges_end();

--- a/test/graph/routing.cpp
+++ b/test/graph/routing.cpp
@@ -1,0 +1,54 @@
+#include "graph/routing.hpp"
+
+#include <exception>
+
+// make sure we get a new main function here
+#define BOOST_TEST_MODULE RoutingGraph
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+using namespace project_x;
+
+inline graph::WeightTimeDistance
+makeWeight(std::uint32_t weight, std::uint32_t time, std::uint32_t distance) {
+  return {weight, time, distance};
+}
+
+// test a construction of an undirected graph from a set of edges
+BOOST_AUTO_TEST_CASE(edge_weight_comparisons) {
+  auto unit = makeWeight(1, 1, 1);
+  auto weight = makeWeight(1, 0, 0);
+  auto time = makeWeight(0, 1, 0);
+  auto distance = makeWeight(0, 0, 1);
+
+  BOOST_CHECK(unit < unit + weight);
+  BOOST_CHECK(unit < unit + time);
+  BOOST_CHECK(unit < unit + distance);
+  BOOST_CHECK(!(unit < unit));
+
+  BOOST_CHECK(unit <= unit + weight);
+  BOOST_CHECK(unit <= unit + time);
+  BOOST_CHECK(unit <= unit + distance);
+  BOOST_CHECK(unit <= unit);
+
+  BOOST_CHECK(unit + weight > unit);
+  BOOST_CHECK(unit + time > unit);
+  BOOST_CHECK(unit + distance > unit);
+  BOOST_CHECK(!(unit > unit));
+
+  BOOST_CHECK(unit + weight >= unit);
+  BOOST_CHECK(unit + time >= unit);
+  BOOST_CHECK(unit + distance >= unit);
+  BOOST_CHECK(unit >= unit);
+
+  BOOST_CHECK(unit == unit);
+  BOOST_CHECK(unit != unit + unit);
+
+  auto twice = unit;
+  twice += unit;
+  BOOST_CHECK(unit < twice);
+  BOOST_CHECK(unit == twice - unit);
+  auto once = twice;
+  once -= unit;
+  BOOST_CHECK(unit == once);
+}


### PR DESCRIPTION
Add decorators for graphs that allow associating graphs with cost/data.
This is a first step on making the graphs navigable, adding actual cost to the links. 