### PR TITLE
Rendering Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ endif()
 # Sub-Projects
 add_subdirectory(src/graph)
 add_subdirectory(src/algorithm)
+add_subdirectory(src/geometry)
 add_subdirectory(src/log)
 add_subdirectory(src/io)
 

--- a/include/geometry/constants.hpp
+++ b/include/geometry/constants.hpp
@@ -1,0 +1,20 @@
+#ifndef PROJECT_X_GEOMETRY_CONSTANTS_HPP_
+#define PROJECT_X_GEOMETRY_CONSTANTS_HPP_
+
+#include <cmath>
+
+namespace project_x {
+namespace geometry {
+namespace constants {
+// radius of planet earth in meters
+const constexpr long double earth_radius_meters = 6372797.560856;
+// mercator projection limits the values based on a tubular projection of the
+// earth surface
+const constexpr long double merc_max_extent = earth_radius_meters * M_PI;
+// the epsg ellipsoid does not support latitudes close to the poles
+const constexpr double epsg3857_max_latitude = 85.051128779806592377;
+} // namespace constants
+} // namespace geometry
+} // namespace project_x
+
+#endif // PROJECT_X_GEOMETRY_CONSTANTS_HPP_

--- a/include/geometry/coordinate.hpp
+++ b/include/geometry/coordinate.hpp
@@ -1,0 +1,54 @@
+#ifndef PROJECT_X_GEOMETRY_COORDINATE_HPP_
+#define PROJECT_X_GEOMETRY_COORDINATE_HPP_
+
+#include "traits/strong_typedef.hpp"
+#include "traits/typemap.hpp"
+
+#include <cmath>
+
+namespace project_x {
+namespace geometry {
+
+// standard google polyline precision for internal coordinate precision
+const constexpr std::int32_t fixed_coordinate_precision = 1e05;
+
+// lat/lon coordinates in fixed precision integer representation
+using FixedWGSLatitude =
+    traits::strong_typedef<std::int32_t, traits::typemap::tagWGSLatitude>;
+using FixedWGSLongitude =
+    traits::strong_typedef<std::int32_t, traits::typemap::tagWGSLongitude>;
+
+// a fixed precision WGS84 coordinate
+struct WGS84FixedCoorinate {
+  FixedWGSLatitude latitude;
+  FixedWGSLongitude longitude;
+};
+
+using FixedWebMercLatitude =
+    traits::strong_typedef<std::int32_t, traits::typemap::tagWebMercLatitude>;
+using FixedWebMercLongitude =
+    traits::strong_typedef<std::int32_t, traits::typemap::tagWebMercLongitude>;
+
+// a fixed precision WGS84 coordinate
+struct WebMercatorFixedCoorinate {
+  FixedWebMercLatitude latitude;
+  FixedWebMercLongitude longitude;
+};
+
+// conversion functions to ensure easy adjustment of precision, if needed at
+// some point
+namespace coordinate {
+template <typename lat_or_lon> double to_floating(lat_or_lon value) {
+  return static_cast<double>(value.base()) / fixed_coordinate_precision;
+}
+
+inline std::int32_t to_fixed(double value) {
+  return static_cast<std::int32_t>(
+      std::round(value * fixed_coordinate_precision));
+}
+} // namespace coordinate
+
+} // namespace geometry
+} // namespace project_x
+
+#endif // PROJECT_X_GEOMETRY_COORDINATE_HPP_

--- a/include/geometry/projection.hpp
+++ b/include/geometry/projection.hpp
@@ -1,0 +1,18 @@
+#ifndef PROJECT_X_GEOMETRY_PROJECTION_HPP_
+#define PROJECT_X_GEOMETRY_PROJECTION_HPP_
+
+#include "geometry/coordinate.hpp"
+
+namespace project_x {
+namespace geometry {
+
+// projection functions allow converting between coordinate formats
+WebMercatorFixedCoorinate projectWgsWebMerc(WGS84FixedCoorinate const);
+
+// TODO possibly implement back projection
+// WGS84FixedCoorinate projectWebMercWgs(WebMercatorFixedCoorinate const);
+
+} // namespace geometry
+} // namespace project_x
+
+#endif // PROJECT_X_GEOMETRY_PROJECTION_HPP_

--- a/include/traits/strong_typedef.hpp
+++ b/include/traits/strong_typedef.hpp
@@ -1,0 +1,156 @@
+#ifndef PROJECT_X_TRAITS_STRONG_TYPEDEF_HPP_
+#define PROJECT_X_TRAITS_STRONG_TYPEDEF_HPP_
+
+#include "traits/typemap.hpp"
+#include <iostream>
+
+namespace project_x {
+namespace traits {
+template <typename base_type, typemap type_tag> struct strong_typedef {
+  using value_type = base_type;
+  value_type value;
+
+  explicit operator value_type &();
+  explicit operator value_type() const;
+
+  value_type base() const;
+
+  // comparisons
+  bool operator<(strong_typedef<base_type, type_tag> const) const;
+  bool operator<=(strong_typedef<base_type, type_tag> const) const;
+  bool operator>(strong_typedef<base_type, type_tag> const) const;
+  bool operator>=(strong_typedef<base_type, type_tag> const) const;
+  bool operator==(strong_typedef<base_type, type_tag> const) const;
+  bool operator!=(strong_typedef<base_type, type_tag> const) const;
+
+  // increment/decrement
+  strong_typedef<base_type, type_tag> operator++();
+  strong_typedef<base_type, type_tag> operator++(int);
+  strong_typedef<base_type, type_tag> operator--();
+  strong_typedef<base_type, type_tag> operator--(int);
+
+  // longer shifts
+  strong_typedef<base_type, type_tag>
+  operator+(strong_typedef<base_type, type_tag> const);
+  strong_typedef<base_type, type_tag>
+  operator+=(strong_typedef<base_type, type_tag> const);
+  strong_typedef<base_type, type_tag>
+  operator-(strong_typedef<base_type, type_tag> const);
+  strong_typedef<base_type, type_tag>
+  operator-=(strong_typedef<base_type, type_tag> const);
+
+  // forward outstream
+  friend std::ostream &operator<<(std::ostream &os, strong_typedef const type) {
+    os << type.value;
+    return os;
+  }
+};
+
+template <typename base_type, typemap type_tag>
+strong_typedef<base_type, type_tag>::operator value_type &() {
+  return value;
+}
+template <typename base_type, typemap type_tag>
+strong_typedef<base_type, type_tag>::operator value_type() const {
+  return value;
+}
+template <typename base_type, typemap type_tag>
+base_type strong_typedef<base_type, type_tag>::base() const {
+  return value;
+}
+
+// comparisons
+template <typename base_type, typemap type_tag>
+bool strong_typedef<base_type, type_tag>::
+operator<(strong_typedef<base_type, type_tag> const rhs) const {
+  return value < rhs.value;
+}
+template <typename base_type, typemap type_tag>
+bool strong_typedef<base_type, type_tag>::
+operator<=(strong_typedef<base_type, type_tag> const rhs) const {
+  return value <= rhs.value;
+}
+template <typename base_type, typemap type_tag>
+bool strong_typedef<base_type, type_tag>::
+operator>(strong_typedef<base_type, type_tag> const rhs) const {
+  return value > rhs.value;
+}
+template <typename base_type, typemap type_tag>
+bool strong_typedef<base_type, type_tag>::
+operator>=(strong_typedef<base_type, type_tag> const rhs) const {
+  return value >= rhs.value;
+}
+template <typename base_type, typemap type_tag>
+bool strong_typedef<base_type, type_tag>::
+operator==(strong_typedef<base_type, type_tag> const rhs) const {
+  return value == rhs.value;
+}
+template <typename base_type, typemap type_tag>
+bool strong_typedef<base_type, type_tag>::
+operator!=(strong_typedef<base_type, type_tag> const rhs) const {
+  return value != rhs.value;
+}
+
+// increment/decrement
+template <typename base_type, typemap type_tag>
+strong_typedef<base_type, type_tag> strong_typedef<base_type, type_tag>::
+operator++(int) {
+  auto const result = *this;
+  ++value;
+  return result;
+}
+template <typename base_type, typemap type_tag>
+strong_typedef<base_type, type_tag> strong_typedef<base_type, type_tag>::
+operator++() {
+  ++value;
+  return *this;
+}
+template <typename base_type, typemap type_tag>
+strong_typedef<base_type, type_tag> strong_typedef<base_type, type_tag>::
+operator--(int) {
+  auto const result = *this;
+  --value;
+  return result;
+}
+template <typename base_type, typemap type_tag>
+strong_typedef<base_type, type_tag> strong_typedef<base_type, type_tag>::
+operator--() {
+  --value;
+  return *this;
+}
+
+// longer shifts
+template <typename base_type, typemap type_tag>
+strong_typedef<base_type, type_tag> strong_typedef<base_type, type_tag>::
+operator+(strong_typedef<base_type, type_tag> const rhs) {
+  auto copy = *this;
+  copy += rhs;
+  return copy;
+}
+
+template <typename base_type, typemap type_tag>
+strong_typedef<base_type, type_tag> strong_typedef<base_type, type_tag>::
+operator+=(strong_typedef<base_type, type_tag> const rhs) {
+  value += rhs.value;
+  return *this;
+}
+
+template <typename base_type, typemap type_tag>
+strong_typedef<base_type, type_tag> strong_typedef<base_type, type_tag>::
+operator-(strong_typedef<base_type, type_tag> const rhs) {
+  auto copy = *this;
+  copy -= rhs;
+  return copy;
+}
+
+template <typename base_type, typemap type_tag>
+strong_typedef<base_type, type_tag> strong_typedef<base_type, type_tag>::
+operator-=(strong_typedef<base_type, type_tag> const rhs) {
+  value -= rhs.value;
+  return *this;
+}
+
+} // namespace traits
+} // namespace project_x
+
+#endif // PROJECT_X_TRAITS_STRONG_TYPEDEF_HPP_

--- a/include/traits/typemap.hpp
+++ b/include/traits/typemap.hpp
@@ -7,8 +7,10 @@ namespace traits {
 // a list of tags for each strong typedef
 enum class typemap {
   // geometric types
-  tagLongitude,
-  tagLatitude,
+  tagWGSLongitude,
+  tagWGSLatitude,
+  tagWebMercLongitude,
+  tagWebMercLatitude,
   // ID types
   tagNodeID,
   tagEdgeID

--- a/include/traits/typemap.hpp
+++ b/include/traits/typemap.hpp
@@ -1,0 +1,20 @@
+#ifndef PROJECT_X_TRAITS_TYPEMAP_HPP_
+#define PROJECT_X_TRAITS_TYPEMAP_HPP_
+
+namespace project_x {
+namespace traits {
+
+// a list of tags for each strong typedef
+enum class typemap {
+  // geometric types
+  tagLongitude,
+  tagLatitude,
+  // ID types
+  tagNodeID,
+  tagEdgeID
+};
+
+} // namespace traits
+} // namespace project_x
+
+#endif // PROJECT_X_TRAITS_TYPEMAP_HPP_

--- a/src/geometry/CMakeLists.txt
+++ b/src/geometry/CMakeLists.txt
@@ -1,0 +1,13 @@
+set (geometry_SOURCES
+  "projection.cpp")
+
+add_library(Xgeometry STATIC
+  ${geometry_SOURCES})
+
+#required libs to build static geometry library
+target_link_libraries(Xgeometry
+  ${MAYBE_COVERAGE_LIBRARIES})
+
+#additional includes for geometry library
+target_include_directories(Xgeometry SYSTEM PUBLIC
+  )

--- a/src/geometry/projection.cpp
+++ b/src/geometry/projection.cpp
@@ -1,0 +1,42 @@
+#include "geometry/projection.hpp"
+#include "geometry/constants.hpp"
+
+#include <cmath>
+#include <utility>
+
+namespace {
+// conversion factors between different angle formats
+const constexpr long double degree_to_rad = 0.017453292519943295769236907684886;
+const constexpr long double rad_to_degree = 1.0 / degree_to_rad;
+} // namespace
+
+namespace project_x {
+namespace geometry {
+
+// projection functions allow converting between coordinate formats
+WebMercatorFixedCoorinate projectWgsWebMerc(WGS84FixedCoorinate const wgs) {
+  auto const longitude_radians =
+      coordinate::to_floating(wgs.longitude) * degree_to_rad;
+
+  auto projected_longitude = 128.0 / M_PI * (longitude_radians + M_PI);
+
+  auto web_longitude =
+      FixedWebMercLongitude{coordinate::to_fixed(projected_longitude)};
+
+  auto const latitude_radians =
+      coordinate::to_floating(wgs.latitude) * degree_to_rad;
+
+  auto const sin_lat = std::sin(latitude_radians);
+
+  auto projected_latitude =
+      -((rad_to_degree * std::log((1 + sin_lat) / (1 - sin_lat))) * 64. / 180. -
+        128);
+
+  auto web_latitude =
+      FixedWebMercLatitude{coordinate::to_fixed(projected_latitude)};
+
+  return {std::move(web_latitude), std::move(web_longitude)};
+}
+
+} // namespace geometry
+} // namespace project_x

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,7 @@ ADD_DEFINITIONS(-DBOOST_TEST_DYN_LINK)
 
 add_subdirectory(graph)
 add_subdirectory(algorithm)
+add_subdirectory(geometry)
 add_subdirectory(traits)
 add_subdirectory(container)
 add_subdirectory(builder)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,7 @@ ADD_DEFINITIONS(-DBOOST_TEST_DYN_LINK)
 
 add_subdirectory(graph)
 add_subdirectory(algorithm)
+add_subdirectory(traits)
 add_subdirectory(container)
 add_subdirectory(builder)
 add_subdirectory(io)

--- a/test/geometry/CMakeLists.txt
+++ b/test/geometry/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(testLIBS
+  Xgeometry
+  ${Boost_SYSTEM_LIBRARY}
+  ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+
+set(testINCLUDES
+  )
+
+add_unit_test(coordinate coordinate.cpp "${testLIBS}" "${testINCLUDES}")
+add_unit_test(projection projection.cpp "${testLIBS}" "${testINCLUDES}")

--- a/test/geometry/coordinate.cpp
+++ b/test/geometry/coordinate.cpp
@@ -1,0 +1,24 @@
+#include "geometry/coordinate.hpp"
+
+// make sure we get a new main function here
+#define BOOST_TEST_MODULE Geometry
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+using namespace project_x;
+
+namespace {
+geometry::WGS84FixedCoorinate make_coordinate(double lat, double lon) {
+  return {geometry::FixedWGSLatitude{geometry::coordinate::to_fixed(lat)},
+          geometry::FixedWGSLongitude{geometry::coordinate::to_fixed(lon)}};
+}
+}
+
+// test a construction of an undirected graph from a set of edges
+BOOST_AUTO_TEST_CASE(fixed_floating) {
+  auto coordinate = make_coordinate(90, 180);
+  BOOST_CHECK_EQUAL(geometry::coordinate::to_floating(coordinate.latitude),
+                    90.0);
+  BOOST_CHECK_EQUAL(geometry::coordinate::to_floating(coordinate.longitude),
+                    180.0);
+}

--- a/test/geometry/projection.cpp
+++ b/test/geometry/projection.cpp
@@ -1,0 +1,34 @@
+#include "geometry/projection.hpp"
+#include "geometry/coordinate.hpp"
+
+#include <iostream>
+
+// make sure we get a new main function here
+#define BOOST_TEST_MODULE Geometry
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+using namespace project_x;
+
+geometry::WGS84FixedCoorinate make_coordinate(double const lat,
+                                              double const lon) {
+  return {geometry::FixedWGSLatitude{geometry::coordinate::to_fixed(lat)},
+          geometry::FixedWGSLongitude{geometry::coordinate::to_fixed(lon)}};
+}
+
+// test a construction of an undirected graph from a set of edges
+BOOST_AUTO_TEST_CASE(mercator_projection) {
+  auto c1 = make_coordinate(0, 0);
+  auto c1m = geometry::projectWgsWebMerc(c1);
+  BOOST_CHECK_CLOSE(128.0, geometry::coordinate::to_floating(c1m.latitude),
+                    0.001);
+  BOOST_CHECK_CLOSE(128.0, geometry::coordinate::to_floating(c1m.longitude),
+                    0.001);
+
+  auto c2 = make_coordinate(45, 135);
+  auto c2m = geometry::projectWgsWebMerc(c2);
+  BOOST_CHECK_CLOSE(92.0896, geometry::coordinate::to_floating(c2m.latitude),
+                    0.001);
+  BOOST_CHECK_CLOSE(224.0, geometry::coordinate::to_floating(c2m.longitude),
+                    0.001);
+}

--- a/test/traits/CMakeLists.txt
+++ b/test/traits/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(testLIBS
+  ${Boost_SYSTEM_LIBRARY}
+  ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY})
+
+set(testINCLUDES
+  )
+
+add_unit_test("strong_typedef" "strong_typedef.cpp" "${testLIBS}" "${testINCLUDES}")

--- a/test/traits/strong_typedef.cpp
+++ b/test/traits/strong_typedef.cpp
@@ -1,0 +1,57 @@
+#include "traits/strong_typedef.hpp"
+#include "traits/typemap.hpp"
+
+#include <sstream>
+
+// make sure we get a new main function here
+#define BOOST_TEST_MODULE Traits
+#define BOOST_TEST_MAIN
+#include <boost/test/unit_test.hpp>
+
+using namespace project_x;
+
+BOOST_AUTO_TEST_CASE(id_type) {
+  using TestID = traits::strong_typedef<int, traits::typemap::tagNodeID>;
+
+  auto id = TestID{1};
+  auto id_2 = TestID{2};
+  BOOST_CHECK(id != id_2);
+  BOOST_CHECK(id < id_2);
+  BOOST_CHECK(id <= id_2);
+  BOOST_CHECK(id_2 > id);
+  BOOST_CHECK(id_2 >= id);
+
+  auto id_2_2 = id;
+  ++id_2_2;
+  auto id_1_2 = id++;
+  id--;
+
+  BOOST_CHECK_EQUAL(id_2, id_2_2);
+  BOOST_CHECK_EQUAL(id, id_1_2);
+
+  auto id_1_3 = id_2_2;
+  --id_1_3;
+  BOOST_CHECK_EQUAL(id, id_1_3);
+
+  BOOST_CHECK_EQUAL(id_2, id + id);
+  BOOST_CHECK_EQUAL(id_2 - id, id);
+
+  auto id_2_4 = id_2;
+  id_2_4 -= id;
+  BOOST_CHECK_EQUAL(id_2_4, id);
+  id_2_4 += id;
+  BOOST_CHECK_EQUAL(id_2_4, id_2);
+
+  auto base = static_cast<int>(id);
+  BOOST_CHECK_EQUAL(base, id.base());
+
+  auto &base_ref = static_cast<int &>(id);
+  ++base_ref;
+  BOOST_CHECK_EQUAL(id, id_2);
+  --id;
+
+  std::ostringstream oss;
+  oss << id;
+
+  BOOST_CHECK_EQUAL(oss.str(), "1");
+}


### PR DESCRIPTION
This PR aims at the implementation of supporting rendering for graphs.
For this effort, the following list of items will be implemented:

 - [x] strong typedef (lat-lon mixup avoidance)
 - [x] geometric coordinates
 - [ ] ~geometry container~
 - [ ] ~visual components: either of~
    - ~png renderer~
    - ~tile server~

----

Limiting the scope of this PR, this PR only adds basic coordinate support. To fully support usage, we first need to define a Plugin infrastructure.